### PR TITLE
copy model rawAttributes to attributes if not exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,10 @@ function removeDuplicateRecords(collection) {
  */
 function jsonapify(data, model, selfUrl, context) {
   const includedData = [];
+  if (model.attributes === undefined) {
+    model.attributes = model.rawAttributes;
+  }
+
   const idAttribute = Object.keys(model.attributes).filter(byPrimaryKey(model))[0];
   const excluded = [idAttribute];
 


### PR DESCRIPTION
Fixes critical error with Sequelize 6.6.2 and Feathers 4.5.11.